### PR TITLE
Feature/tuneable shift sensor

### DIFF
--- a/src/firmware/cfgstore.c
+++ b/src/firmware/cfgstore.c
@@ -13,10 +13,8 @@
 
 #include <string.h>
 
-
 #define EEPROM_CONFIG_PAGE		0
 #define EEPROM_PSTATE_PAGE		1
-
 
 #define EEPROM_OK					0
 #define EEPROM_ERROR_SELECT_PAGE	1
@@ -27,8 +25,6 @@
 #define EEPROM_ERROR_ERASE			6
 #define EEPROM_ERROR_WRITE			7
 
-
-
 static const uint8_t default_current_limits[] = { 7, 15, 23, 31, 43, 55, 67, 79, 91 };
 
 typedef struct
@@ -38,12 +34,10 @@ typedef struct
 	uint8_t checksum;
 } header_t;
 
-
 static header_t header;
 
 config_t g_config;
 pstate_t g_pstate;
-
 
 static uint8_t read(uint8_t page, uint8_t version, uint8_t* dst, uint8_t size);
 static uint8_t write(uint8_t page, uint8_t version, uint8_t* src, uint8_t size);
@@ -68,7 +62,6 @@ void cfgstore_init()
 		load_default_pstate();
 	}
 }
-
 
 bool cfgstore_reset_config()
 {
@@ -97,7 +90,6 @@ bool cfgstore_save_pstate()
 {
 	return write_pstate();
 }
-
 
 static bool read_config()
 {
@@ -159,8 +151,9 @@ static void load_default_config()
 	g_config.max_battery_x100v = 5460;
 	g_config.low_cut_off_v = 42;
 
-	g_config.use_speed_sensor = 1;
 	g_config.use_display = 1;
+	g_config.use_speed_sensor = 1;
+	g_config.use_shift_sensor = 1;
 	g_config.use_push_walk = 1;
 	g_config.use_temperature_sensor = TEMPERATURE_SENSOR_CONTR | TEMPERATURE_SENSOR_MOTOR;
 
@@ -176,6 +169,9 @@ static void load_default_config()
 	g_config.throttle_start_voltage_mv = 900;
 	g_config.throttle_end_voltage_mv = 3600;
 	g_config.throttle_start_percent = 1;
+
+	g_config.shift_interrupt_duration_ms = 600;
+	g_config.shift_interrupt_current_threshold_percent = 10;
 
 	g_config.show_temperature_push_walk = 0;
 

--- a/src/firmware/cfgstore.h
+++ b/src/firmware/cfgstore.h
@@ -51,8 +51,9 @@ typedef struct
 	uint8_t max_speed_kph;
 
 	// externals
-	uint8_t use_speed_sensor;
 	uint8_t use_display;
+	uint8_t use_speed_sensor;
+	uint8_t use_shift_sensor;
 	uint8_t use_push_walk;
 	uint8_t use_temperature_sensor;
 
@@ -70,6 +71,10 @@ typedef struct
 	uint16_t throttle_start_voltage_mv;
 	uint16_t throttle_end_voltage_mv;
 	uint8_t throttle_start_percent;
+
+	// shift interrupt options
+	uint16_t shift_interrupt_duration_ms;
+	uint8_t shift_interrupt_current_threshold_percent;
 
 	// misc
 	uint8_t show_temperature_push_walk;

--- a/src/tool/View/SystemView.xaml
+++ b/src/tool/View/SystemView.xaml
@@ -61,8 +61,8 @@
 			<TextBlock Grid.Column="0" Grid.Row="5" Margin="0 10 0 0" Text="Max Speed (km/h):" Visibility="{Binding ConfigVm.UseMetricUnits, Converter={StaticResource BoolToVis}}" />
 			<TextBox Grid.Column="2" Grid.Row="5" Margin="0 10 0 0" Width="60" HorizontalAlignment="Right" Text="{Binding ConfigVm.MaxSpeedKph, UpdateSourceTrigger=PropertyChanged}" Visibility="{Binding ConfigVm.UseMetricUnits, Converter={StaticResource BoolToVis}}" />
 
-			<TextBlock Grid.Column="0" Grid.Row="6" Margin="0 10 0 0" Text="Max Speed (mph):" Visibility="{Binding ConfigVm.UseImperialUnits, Converter={StaticResource BoolToVis}}" />
-			<TextBox Grid.Column="2" Grid.Row="6" Margin="0 10 0 0" Width="60" HorizontalAlignment="Right" Text="{Binding ConfigVm.MaxSpeedMph, UpdateSourceTrigger=PropertyChanged}" Visibility="{Binding ConfigVm.UseImperialUnits, Converter={StaticResource BoolToVis}}" />
+			<TextBlock Grid.Column="0" Grid.Row="5" Margin="0 10 0 0" Text="Max Speed (mph):" Visibility="{Binding ConfigVm.UseImperialUnits, Converter={StaticResource BoolToVis}}" />
+			<TextBox Grid.Column="2" Grid.Row="5" Margin="0 10 0 0" Width="60" HorizontalAlignment="Right" Text="{Binding ConfigVm.MaxSpeedMph, UpdateSourceTrigger=PropertyChanged}" Visibility="{Binding ConfigVm.UseImperialUnits, Converter={StaticResource BoolToVis}}" />
 		</Grid>
 
 
@@ -154,6 +154,7 @@
 				<RowDefinition Height="Auto" />
 				<RowDefinition Height="Auto" />
 				<RowDefinition Height="Auto" />
+				<RowDefinition Height="Auto" />
 			</Grid.RowDefinitions>
 
 			<TextBlock Grid.Row="0" Text="Features" FontSize="18" FontWeight="Bold" />
@@ -164,10 +165,13 @@
 			<TextBlock Grid.Column="0" Grid.Row="2" Margin="0 8 0 0" Text="Speed Sensor:" />
 			<CheckBox Grid.Column="2" Grid.Row="2" Margin="0 8 0 0" HorizontalAlignment="Right"  IsChecked="{Binding ConfigVm.UseSpeedSensor, UpdateSourceTrigger=PropertyChanged}" />
 
-			<TextBlock Grid.Column="0" Grid.Row="3" Margin="0 8 0 0" Text="Walk Mode:" />
-			<CheckBox Grid.Column="2" Grid.Row="3" Margin="0 8 0 0" HorizontalAlignment="Right"  IsChecked="{Binding ConfigVm.UsePushWalk, UpdateSourceTrigger=PropertyChanged}" />
+			<TextBlock Grid.Column="0" Grid.Row="3" Margin="0 8 0 0" Text="Shift Sensor:" />
+			<CheckBox Grid.Column="2" Grid.Row="3" Margin="0 8 0 0" HorizontalAlignment="Right"  IsChecked="{Binding ConfigVm.UseShiftSensor, UpdateSourceTrigger=PropertyChanged}" />
 
-			<TextBlock Grid.Column="0" Grid.Row="4" Margin="0 8 0 0" Text="Temperature Sensor:">
+			<TextBlock Grid.Column="0" Grid.Row="4" Margin="0 8 0 0" Text="Walk Mode:" />
+			<CheckBox Grid.Column="2" Grid.Row="4" Margin="0 8 0 0" HorizontalAlignment="Right"  IsChecked="{Binding ConfigVm.UsePushWalk, UpdateSourceTrigger=PropertyChanged}" />
+
+			<TextBlock Grid.Column="0" Grid.Row="5" Margin="0 8 0 0" Text="Temperature Sensor:">
 				<TextBlock.ToolTip>
 					<TextBlock Width="300" TextWrapping="Wrap">
 						Select which temperature sensors to use for thermal limiting if motor/controller gets to hot.
@@ -177,7 +181,7 @@
 					</TextBlock>
 				</TextBlock.ToolTip>
 			</TextBlock>
-			<ComboBox Grid.Column="2" Grid.Row="4" Margin="0 8 0 0" Width="80" Height="20" HorizontalAlignment="Right" ItemsSource="{Binding ConfigVm.TemperatureSensorOptions}" SelectedItem="{Binding ConfigVm.UseTemperatureSensor, UpdateSourceTrigger=PropertyChanged}" />
+			<ComboBox Grid.Column="2" Grid.Row="5" Margin="0 8 0 0" Width="80" Height="20" HorizontalAlignment="Right" ItemsSource="{Binding ConfigVm.TemperatureSensorOptions}" SelectedItem="{Binding ConfigVm.UseTemperatureSensor, UpdateSourceTrigger=PropertyChanged}" />
 
 		</Grid>
 
@@ -198,7 +202,6 @@
 
 			<TextBlock Grid.Row="0" Text="Speed Sensor" FontSize="18" FontWeight="Bold" />
 
-
 			<TextBlock Grid.Column="0" Grid.Row="2" Margin="0 8 0 0" Text="Wheel Size (inch):" />
 			<TextBox Grid.Column="2" Grid.Row="2" Margin="0 8 0 0" Width="60" HorizontalAlignment="Right" Text="{Binding ConfigVm.WheelSizeInch, UpdateSourceTrigger=LostFocus}" />
 
@@ -218,11 +221,38 @@
 				<RowDefinition Height="Auto" />
 				<RowDefinition Height="Auto" />
 				<RowDefinition Height="Auto" />
+				<RowDefinition Height="10" />
+				<RowDefinition Height="Auto" />
+				<RowDefinition Height="Auto" />
 			</Grid.RowDefinitions>
 
-			<TextBlock Grid.Row="0" Text="Miscellaneous" FontSize="18" FontWeight="Bold" />
+			<TextBlock Grid.Row="0" Text="Shift Sensor" FontSize="18" FontWeight="Bold" />
 
-			<TextBlock Grid.Column="0" Grid.Row="1" Margin="0 10 0 0" Text="Show Temperature during Walk Mode:">
+			<TextBlock Grid.Column="0" Grid.Row="1" Margin="0 8 0 0" Text="Shift Interrupt Duration (ms):">
+				<TextBlock.ToolTip>
+					<TextBlock Width="300" TextWrapping="Wrap">
+						How long the power interrupt will last when the gear sensor is triggered.
+					</TextBlock>
+				</TextBlock.ToolTip>
+			</TextBlock>	
+			<TextBox Grid.Column="2" Grid.Row="1" Margin="0 8 0 0" Width="60" HorizontalAlignment="Right" Text="{Binding ConfigVm.ShiftInterruptDuration, UpdateSourceTrigger=PropertyChanged}" />
+
+			<TextBlock Grid.Column="0" Grid.Row="2" Margin="0 8 0 0" Text="Shift Current Threshold (%):">
+				<TextBlock.ToolTip>
+					<TextBlock Width="300" TextWrapping="Wrap">
+						Maximum motor current during shifting expressed as a percentage of "Max Current (A)".
+						If motor current is below this threshold, then no power cut will happen.
+						If motor current is higher than this threshold, then current will be reduced to this value during the shift.
+						For example, if Max Current is 30 amps, and Shift Current Threshold is 10%, then current through the motor during
+						shifts will be limited to 3 amps.
+					</TextBlock>
+				</TextBlock.ToolTip>
+			</TextBlock>
+			<TextBox Grid.Column="2" Grid.Row="2" Margin="0 8 0 0" Width="60" HorizontalAlignment="Right" Text="{Binding ConfigVm.ShiftInterruptCurrentThresholdPercent, UpdateSourceTrigger=PropertyChanged}" />
+
+			<TextBlock Grid.Row="4" Text="Miscellaneous" FontSize="18" FontWeight="Bold" />
+
+			<TextBlock Grid.Column="0" Grid.Row="5" Margin="0 10 0 0" Text="Show Temperature during Walk Mode:">
 				<TextBlock.ToolTip>
 					<TextBlock Width="300" TextWrapping="Wrap">
 						Show controller temperature in speed field on display while walk mode is active.
@@ -231,7 +261,7 @@
 					</TextBlock>
 				</TextBlock.ToolTip>
 			</TextBlock>
-			<CheckBox Grid.Column="2" Grid.Row="1" Margin="0 10 0 0" HorizontalAlignment="Right" IsChecked="{Binding ConfigVm.ShowTemperatureOnPushWalk, UpdateSourceTrigger=PropertyChanged}" />
+			<CheckBox Grid.Column="2" Grid.Row="5" Margin="0 10 0 0" HorizontalAlignment="Right" IsChecked="{Binding ConfigVm.ShowTemperatureOnPushWalk, UpdateSourceTrigger=PropertyChanged}" />
 
 		</Grid>
 

--- a/src/tool/ViewModel/ConfigurationViewModel.cs
+++ b/src/tool/ViewModel/ConfigurationViewModel.cs
@@ -188,6 +188,19 @@ namespace BBSFW.ViewModel
 			}
 		}
 
+		public bool UseShiftSensor
+		{
+			get { return _config.UseShiftSensor; }
+			set
+			{
+				if (_config.UseShiftSensor != value)
+				{
+					_config.UseShiftSensor = value;
+					OnPropertyChanged(nameof(UseShiftSensor));
+				}
+			}
+		}
+
 		public bool UsePushWalk
 		{
 			get { return _config.UsePushWalk; }
@@ -331,6 +344,32 @@ namespace BBSFW.ViewModel
 			}
 		}
 
+		public uint ShiftInterruptDuration
+		{
+			get { return _config.ShiftInterruptDuration; }
+			set
+			{
+				if (_config.ShiftInterruptDuration != value)
+				{
+					_config.ShiftInterruptDuration = value;
+					OnPropertyChanged(nameof(ShiftInterruptDuration));
+				}
+			}
+		}
+
+		public uint ShiftInterruptCurrentThresholdPercent
+		{
+			get { return _config.ShiftInterruptCurrentThresholdPercent; }
+			set
+			{
+				if (_config.ShiftInterruptCurrentThresholdPercent != value)
+				{
+					_config.ShiftInterruptCurrentThresholdPercent = value;
+					OnPropertyChanged(nameof(ShiftInterruptCurrentThresholdPercent));
+				}
+			}
+		}
+
 		public bool ShowTemperatureOnPushWalk
 		{
 			get { return _config.ShowTemperatureOnPushWalk; }
@@ -402,7 +441,6 @@ namespace BBSFW.ViewModel
 			}
 		}
 
-
 		public ConfigurationViewModel()
 		{
 			_config = new Configuration();
@@ -458,11 +496,14 @@ namespace BBSFW.ViewModel
 			OnPropertyChanged(nameof(MaxSpeedMph));
 			OnPropertyChanged(nameof(UseDisplay));
 			OnPropertyChanged(nameof(UseSpeedSensor));
+			OnPropertyChanged(nameof(UseShiftSensor));
 			OnPropertyChanged(nameof(UsePushWalk));
 			OnPropertyChanged(nameof(UseTemperatureSensor));
 			OnPropertyChanged(nameof(ThrottleStartVoltageMillivolts));
 			OnPropertyChanged(nameof(ThrottleEndVoltageMillivolts));
 			OnPropertyChanged(nameof(ThrottleStartCurrentPercent));
+			OnPropertyChanged(nameof(ShiftInterruptDuration));
+			OnPropertyChanged(nameof(ShiftInterruptCurrentThresholdPercent));
 			OnPropertyChanged(nameof(PasStartDelayDegrees));
 			OnPropertyChanged(nameof(PasStopDelayMilliseconds));
 			OnPropertyChanged(nameof(PasKeepCurrentPercent));
@@ -486,6 +527,5 @@ namespace BBSFW.ViewModel
 		{
 			return (uint)Math.Round(mph * 1.609344);
 		}
-
 	}
 }


### PR DESCRIPTION
Shift pause duration (ms) and shift power threshold (W) can be tuned by the user through the GUI (or disabled entirely). Shift power threshold is estimated with the nominal battery voltage (also now provided through the GUI) and the maximum configured current. The threshold is computed once at init to save on computational resources while running (thus does not take into account changing battery voltages).