### PR TITLE
added refresh button to GUI for list of available COM ports

### DIFF
--- a/src/tool/View/ConnectionView.xaml
+++ b/src/tool/View/ConnectionView.xaml
@@ -38,6 +38,15 @@
 
 		<StackPanel Grid.Column="2" Grid.Row="0" Height="80" Orientation="Vertical" VerticalAlignment="Center" HorizontalAlignment="Center" Visibility="{Binding IsDisconnected, Converter={StaticResource BoolToVis}}">
 
+			<Button Content="Refresh" Width="120" Command="{Binding RefreshCommand}">
+				<Button.Style>
+					<Style TargetType="{x:Type Button}">
+						<Setter Property="IsEnabled" Value="True" />
+						<Setter Property="Visibility" Value="Visible" />
+					</Style>
+				</Button.Style>
+			</Button>
+
 			<Button Content="Connect" Width="120" Command="{Binding ConnectCommand}">
 				<Button.Style>
 					<Style TargetType="{x:Type Button}">

--- a/src/tool/ViewModel/ConnectionViewModel.cs
+++ b/src/tool/ViewModel/ConnectionViewModel.cs
@@ -129,6 +129,14 @@ namespace BBSFW.ViewModel
 
 		public event Action<EventLogEntry> EventLogReceived;
 
+		public ICommand RefreshCommand
+		{
+			get
+			{
+				return new DelegateCommand(OnRefresh);
+			}
+		}
+
 
 		public ICommand ConnectCommand
 		{
@@ -186,6 +194,11 @@ namespace BBSFW.ViewModel
 			ConfigVersion = 0;
 		}
 
+		private void OnRefresh()
+		{
+			ComPorts = BbsfwConnection.GetComPorts();
+			OnPropertyChanged(nameof(ComPorts));
+		}
 
 		private async void OnConnect()
 		{


### PR DESCRIPTION
Added a "Refresh" button that re-loads the list of available COM ports. Useful when you launch the GUI but forget to plug the USB cable in beforehand. 