### PR TITLE
Cruise control error correction

### DIFF
--- a/src/firmware/app.c
+++ b/src/firmware/app.c
@@ -448,7 +448,7 @@ void apply_cruise(uint8_t* target_current, uint8_t throttle_percent)
 		}
 
 		// pause cruise if throttle touched while cruise active
-		else if (!cruise_paused && !cruise_block_throttle_return && throttle_percent > 0)
+		else if (!cruise_paused && !cruise_block_throttle_return && throttle_percent > 10)
 		{
 			cruise_paused = true;
 			cruise_block_throttle_return = true;
@@ -462,7 +462,7 @@ void apply_cruise(uint8_t* target_current, uint8_t throttle_percent)
 		}
 
 		// reset flag tracking throttle to make sure throttle returns to idle position before engage/disenage cruise with throttle touch
-		else if (cruise_block_throttle_return && throttle_percent == 0)
+		else if (cruise_block_throttle_return && throttle_percent < 10)
 		{
 			cruise_block_throttle_return = false;
 		}

--- a/src/firmware/throttle.c
+++ b/src/firmware/throttle.c
@@ -126,7 +126,7 @@ uint8_t throttle_read()
 		value = max_voltage_adc;
 	}
 
-	throttle_percent = (uint8_t)MAP16(value, min_voltage_adc, max_voltage_adc, 1, 100);
+	throttle_percent = (uint8_t)MAP16(value, min_voltage_adc, max_voltage_adc, 0, 100);
 
 	return throttle_percent;
 }


### PR DESCRIPTION
Since the throttle range is set to 1-100, disarming cruise control via the throttle does not work.
And the throttle range has been extended for more stable operation.