### PR TITLE
modifications to lvc rampdown computations

### DIFF
--- a/src/firmware/fwconfig.h
+++ b/src/firmware/fwconfig.h
@@ -49,7 +49,6 @@
 	#define PAS_PULSES_REVOLUTION				20
 #endif
 
-
  // Applied to both motor and controller tmeperature sensor
 #define MAX_TEMPERATURE							85
 
@@ -62,7 +61,6 @@
 // max temperature.
 #define MAX_TEMPERATURE_LOW_CURRENT_PERCENT		20
 
-
 // No battery percent mapping
 #define BATTERY_PERCENT_MAP_NONE				0
 // Map battery percent to provide a linear relationship on the
@@ -72,18 +70,20 @@
 // Select battery percent mapping
 #define BATTERY_PERCENT_MAP						BATTERY_PERCENT_MAP_NONE
 
-// Current ramp down starts at LVC + (VOLTAGE_RANGE * LVC_RAMP_DOWN_OFFSET_PERCENT / 100)
-// Example:
-// LVC is 42V, max voltage at 58.8
-// Range = 58.8 - 42 = 16.8
-// Ramp down starts at 42V + Range * 0.09 = 43.5
-#define LVC_RAMP_DOWN_OFFSET_PERCENT			9
+// Time with no motor load until battery voltage is updated to avoid voltage sag.
+#define BATTERY_NO_LOAD_DELAY_MS		2000
+
+// Padding values for voltage range of battery.
+#define BATTERY_FULL_OFFSET_PERCENT		8
+#define BATTERY_EMPTY_OFFSET_PERCENT	8
+
+// Battery SOC percentage when current ramp down starts.
+#define LVC_RAMP_DOWN_OFFSET_PERCENT			10
 
 // Maximum allowed motor current in percent of maximum configured current (A)
-// to still apply when LVC has been reached.
-// Motor current is ramped down linearly until this value when approacing LVC.
+// to still apply when 0% battery has been reached.
+// Motor current is ramped down linearly until this value when approaching "empty".
 #define LVC_LOW_CURRENT_PERCENT					20
-
 
 // Size of speed limit ramp down interval.
 // If max speed is 50 and this is set to 3 then the
@@ -92,7 +92,7 @@
 #define SPEED_LIMIT_RAMP_DOWN_INTERVAL_KPH		3
 
 // Current ramp down (e.g. when releasing throttle, stop pedaling etc.) in percent per 10 millisecond.
-// Specifying 1 will make ramp down periond 1 second if relasing from full throttle.
+// Specifying 1 will make ramp down periond 1 second if releasing from full throttle.
 // Set to 100 to disable
 #define CURRENT_RAMP_DOWN_PERCENT_10MS			5
 
@@ -118,7 +118,6 @@
 // actual cadence is lower it will be overriden by this
 // configured value.
 #define TORQUE_POWER_LOWER_RPM_X10				300
-
 
 // Number of PAS sensor pulses to engage cruise mode,
 // there are 24 pulses per revolution.


### PR DESCRIPTION
I'm proposing a very slight modification for how the LVC rampdown computations are performed. I changed LVC_RAMP_DOWN_OFFSET_PERCENT to reflect the battery percentage when LVC rampdown starts, and the LVC rampdown ends when 0% battery is reached (the padded value), thus protecting the battery a bit more from discharge at configured LVC (and lining up with the displayed battery percentage). 

Also moved the defines from battery.c into fwconfig.h and added some more detailed comments / examples for the battery math.