### PR TITLE
Global throttle speed lim

### DIFF
--- a/src/firmware/cfgstore.c
+++ b/src/firmware/cfgstore.c
@@ -178,8 +178,8 @@ static void load_default_config()
 	g_config.pas_keep_current_percent = 60;
 	g_config.pas_keep_current_cadence_rpm = 40;
 
-	g_config.throttle_start_voltage_mv_u16l = (uint8_t)900;
-	g_config.throttle_start_voltage_mv_u16h = (uint8_t)(900 >> 8);
+	g_config.throttle_start_voltage_mv_u16l = (uint8_t)1000;
+	g_config.throttle_start_voltage_mv_u16h = (uint8_t)(1000 >> 8);
 	g_config.throttle_end_voltage_mv_u16l = (uint8_t)3600;
 	g_config.throttle_end_voltage_mv_u16h = (uint8_t)(3600 >> 8);
 	g_config.throttle_start_percent = 1;

--- a/src/tool/View/SystemView.xaml
+++ b/src/tool/View/SystemView.xaml
@@ -98,8 +98,9 @@
 						be used in order to comply with such laws.
 						<LineBreak />
 						<LineBreak />
-						When this option is enabled the configured global speed limit will override the 
-						assist level speed limit when throttle is used.
+						When this option is enabled the configured global throttle speed limit will override the 
+						assist level speed limit while using throttle and not pedaling. Throttle must still
+						be enabled on each individual assist level for this option to apply.
 						<LineBreak />
 						<LineBreak />
 						<Run FontWeight="Bold">Disabled</Run> - No global speed limit.


### PR DESCRIPTION
According to discussion in #112 & #216

* Change behavior of global throttle speed limit to NOT override configured assist level speed limit when pedaling

Give feedback if if you do not want this behaviour to change in next release and if so, why.