### PR TITLE
Add Eggrider compatibility option

### DIFF
--- a/src/firmware/app.c
+++ b/src/firmware/app.c
@@ -259,16 +259,13 @@ void app_set_lights(bool on)
 
 void app_set_speed_limit_operation_mode(uint16_t display_speed_limit_rpm)
 {
-	if (SPEED_LIMIT_SPORT_SWITCH_KPH != 0)
+	if (display_speed_limit_rpm == convert_wheel_speed_kph_to_rpm(SPEED_LIMIT_SPORT_SWITCH_KPH))
 	{
-		if (display_speed_limit_rpm == convert_wheel_speed_kph_to_rpm(SPEED_LIMIT_SPORT_SWITCH_KPH))
-		{
-			app_set_operation_mode(OPERATION_MODE_SPORT);
-		}
-		else
-		{
-			app_set_operation_mode(OPERATION_MODE_DEFAULT);
-		}
+		app_set_operation_mode(OPERATION_MODE_SPORT);
+	}
+	else
+	{
+		app_set_operation_mode(OPERATION_MODE_DEFAULT);
 	}
 }
 

--- a/src/firmware/app.c
+++ b/src/firmware/app.c
@@ -257,6 +257,21 @@ void app_set_lights(bool on)
 	}
 }
 
+void app_set_speed_limit_operation_mode(uint16_t display_speed_limit_rpm)
+{
+	if (SPEED_LIMIT_SPORT_SWITCH_KPH != 0)
+	{
+		if (display_speed_limit_rpm == convert_wheel_speed_kph_to_rpm(SPEED_LIMIT_SPORT_SWITCH_KPH))
+		{
+			app_set_operation_mode(OPERATION_MODE_SPORT);
+		}
+		else
+		{
+			app_set_operation_mode(OPERATION_MODE_DEFAULT);
+		}
+	}
+}
+
 void app_set_operation_mode(uint8_t mode)
 {
 	if (operation_mode != mode)
@@ -546,7 +561,7 @@ bool apply_speed_limit(uint8_t* target_current, uint8_t throttle_percent, bool p
 
 	// global throttle speed limit applies if enabled in configuration, PAS is not engaged and throttle is used
 	bool global_throttle_limit_active =
-		!pas_engaged && 
+		!pas_engaged &&
 		throttle_percent > 0 &&
 		g_config.throttle_global_spd_lim_percent > 0 &&
 		(

--- a/src/firmware/app.h
+++ b/src/firmware/app.h
@@ -63,6 +63,7 @@ void app_set_lights(bool on);
 
 void app_set_operation_mode(uint8_t mode);
 void app_set_wheel_max_speed_rpm(uint16_t value);
+void app_set_speed_limit_operation_mode(uint16_t display_speed_limit_rpm);
 
 uint8_t app_get_assist_level();
 uint8_t app_get_lights();

--- a/src/firmware/extcom.c
+++ b/src/firmware/extcom.c
@@ -873,24 +873,28 @@ static int16_t process_bafang_display_write_speed_limit()
 		return KEEP;
 	}
 
-	if (compute_checksum(msgbuf, 4) == msgbuf[4])
-	{
-		uint16_t value = ((msgbuf[2] << 8) | msgbuf[3]);
+	#if (SPEED_LIMIT_SPORT_SWITCH_KPH > 0)
+		if (compute_checksum(msgbuf, 4) == msgbuf[4])
+		{
+			uint16_t value = ((msgbuf[2] << 8) | msgbuf[3]);
 
-		// Enable sport mode if the display sets the speed limit to
-		// the specified value
-		app_set_speed_limit_operation_mode(value);
+			// Enable sport mode if the display sets the speed limit to
+			// the specified value
 
-		// Ignoring speed limit requested by display,
-		// Global speed limit is configured in firmware config tool.
+			app_set_speed_limit_operation_mode(value);
 
-		// app_set_wheel_max_speed_rpm(value);
-	}
-	else
-	{
-		eventlog_write(EVT_ERROR_EXTCOM_CHEKSUM);
-		return DISCARD;
-	}
+
+			// Ignoring speed limit requested by display,
+			// Global speed limit is configured in firmware config tool.
+
+			// app_set_wheel_max_speed_rpm(value);
+		}
+		else
+		{
+			eventlog_write(EVT_ERROR_EXTCOM_CHEKSUM);
+			return DISCARD;
+		}
+	#endif
 
 	return 5;
 }

--- a/src/firmware/extcom.c
+++ b/src/firmware/extcom.c
@@ -868,6 +868,11 @@ static int16_t process_bafang_display_write_lights()
 
 static int16_t process_bafang_display_write_speed_limit()
 {
+	if (msg_len < 5)
+	{
+		return KEEP;
+	}
+
 	if (compute_checksum(msgbuf, 4) == msgbuf[4])
 	{
 		uint16_t value = ((msgbuf[2] << 8) | msgbuf[3]);

--- a/src/firmware/extcom.c
+++ b/src/firmware/extcom.c
@@ -157,7 +157,7 @@ void extcom_process()
 			msgbuf[msg_len++] = uart_read();
 			last_recv_ms = now;
 			discard_until_ms = 0;
-		}	
+		}
 	}
 
 	if (msg_len > 0 && now - last_recv_ms > 100)
@@ -868,26 +868,24 @@ static int16_t process_bafang_display_write_lights()
 
 static int16_t process_bafang_display_write_speed_limit()
 {
-	if (msg_len < 5)
-	{
-		return KEEP;
-	}
-
-	/*
 	if (compute_checksum(msgbuf, 4) == msgbuf[4])
 	{
-		 // Ignoring speed limit requested by display,
-		 // Global speed limit is configured in firmware config tool.
-		 
-		 uint16_t value = ((msgbuf[2] << 8) | msgbuf[3]);
-		 app_set_wheel_max_speed_rpm(value);
+		uint16_t value = ((msgbuf[2] << 8) | msgbuf[3]);
+
+		// Enable sport mode if the display sets the speed limit to
+		// the specified value
+		app_set_speed_limit_operation_mode(value);
+
+		// Ignoring speed limit requested by display,
+		// Global speed limit is configured in firmware config tool.
+
+		// app_set_wheel_max_speed_rpm(value);
 	}
 	else
 	{
 		eventlog_write(EVT_ERROR_EXTCOM_CHEKSUM);
 		return DISCARD;
 	}
-	*/
 
 	return 5;
 }

--- a/src/firmware/extcom.h
+++ b/src/firmware/extcom.h
@@ -13,4 +13,3 @@ void extcom_init();
 void extcom_process();
 
 #endif
-

--- a/src/firmware/fwconfig.h
+++ b/src/firmware/fwconfig.h
@@ -173,8 +173,12 @@
 // to a certain value, use sport mode. The actual speed limit of the motor
 // remains unchanged. This is a workaround; it is not possible to
 // program the controller using an Eggrider as it doesn't understand the
-// bbs-fw protocol. In the app set the "Bafang switch mode" to "Only live data"
-// and set "Max speed OffRoad" to the value set below.
+// bbs-fw protocol. App configuration:
+// - Set "Bafang switch mode" to "Only live data"
+// - Make sure the bbs-fw wheel diameter in inches matches the Eggrider
+//   wheel circumference in mm. Formula:
+//   circumference (mm) = diameter * π * 25.4
+// - Set "Max speed OffRoad" to the value set below.
 #define SPEED_LIMIT_SPORT_SWITCH_KPH 			0 // speed in km/h. Setting to 0 disables this feature
 
 #endif

--- a/src/firmware/fwconfig.h
+++ b/src/firmware/fwconfig.h
@@ -64,7 +64,7 @@
 // No battery percent mapping
 #define BATTERY_PERCENT_MAP_NONE				0
 // Map battery percent to provide a linear relationship on the
-// 5-bar battery indicator of the SW102 display. 
+// 5-bar battery indicator of the SW102 display.
 #define BATTERY_PERCENT_MAP_SW102				1
 
 // Select battery percent mapping
@@ -120,7 +120,7 @@
 	72, 73, 74, 76, 77, 78, 80, 81, 83, 84,		\
 	85, 87, 88, 90, 91, 93, 94, 96, 97, 99,		\
 	100
-	
+
 
 // This value is used when assist level is configured with throttle cadence
 // override flag in config tool. Default is 100%.
@@ -167,6 +167,14 @@
 	#else
 	#define DISPLAY_RANGE_FIELD_DATA		DISPLAY_RANGE_FIELD_POWER
 	#endif
-#endif 
+#endif
+
+// Eggrider compatibility. When the display sets the speed limit
+// to a certain value, use sport mode. The actual speed limit of the motor
+// remains unchanged. This is a workaround; it is not possible to
+// program the controller using an Eggrider as it doesn't understand the
+// bbs-fw protocol. In the app set the "Bafang switch mode" to "Only live data"
+// and set "Max speed OffRoad" to the value set below.
+#define SPEED_LIMIT_SPORT_SWITCH_KPH 			0 // speed in km/h. Setting to 0 disables this feature
 
 #endif


### PR DESCRIPTION
I've been experimenting with trying to get my Eggrider V2 working with bbs-fw. The eggrider has 2 ways in which it can switch between "road" and "offroad" profiles:

1. Hold 2 sets of parameters for the PAS settings etc and reprogram the controller on the fly when switched
2. Just change the display speed limit value when switched.

Neither of these methods work with bbs-fw. For 1, the protocol is different, and for 2, bbs-fw ignores the command from the display, instead only using the global limit programmed by the tool.

This PR attempts to implement functionality where when the display limit is set to a certain value, the controller will switch to sport mode. The Eggrider can then be set to have that speed limit value in off-road mode, therefore switching between the profiles in bbs-fw.

Note that this does **not** attempt to implement any ability for the Eggrider to program the firmware, that would be impractical as the Eggrider would not support the same parameters exposed by bbs-fw. That would be something for the Eggrider folks to work on; I emailed them a month ago to ask, here's the response:

> At the moment, we don’t have any plans to support the bbs-fw open-source firmware for Bafang motors.

This PR is in draft as it's my first time really getting this deep on a BBS02, and I'm currently a little stuck on how to debug this. All I can confirm right now is that it compiles and the motor works as normal, but the new functionality does not work at all yet.