### PR TITLE
bugfix for LVC rampdown current computation

### DIFF
--- a/src/firmware/app.c
+++ b/src/firmware/app.c
@@ -724,17 +724,18 @@ bool apply_low_voltage_limit(uint8_t* target_current)
 		}
 
 		// Ramp down power until LVC_LOW_CURRENT_PERCENT when approaching LVC
-		uint8_t tmp = (uint8_t)MAP32(
+		int8_t tmp = (int8_t)MAP32(
 			voltage_x100,						// value
 			lvc_ramp_down_end_voltage_x100,		// in_min
 			lvc_ramp_down_start_voltage_x100,	// in_max
 			LVC_LOW_CURRENT_PERCENT,			// out_min
 			100									// out_max
 		);
+		uint8_t tmp2 = (uint8_t)CLAMP(tmp, 0, 100);
 
-		if (*target_current > tmp)
+		if (*target_current > tmp2)
 		{
-			*target_current = tmp;
+			*target_current = tmp2;
 			return true;
 		}
 	}

--- a/src/firmware/app.c
+++ b/src/firmware/app.c
@@ -101,10 +101,11 @@ void app_init()
 	padded_voltage_range_x100 = full_voltage_range_x100 - low_voltage_pad_x100 - high_voltage_pad_x100;
 
 	// The LVC ramp down end is at 0% battery, which is LVC + the low padding value.
-	lvc_ramp_down_end_voltage_x100 = (uint16_t)(lvc_voltage_x100 + (full_voltage_range_x100 * BATTERY_EMPTY_OFFSET_PERCENT / 100));
+	lvc_ramp_down_end_voltage_x100 = lvc_voltage_x100 + low_voltage_pad_x100;
 
-	// The LVC ramp down starts at 10% battery, using the padded range.
-	lvc_ramp_down_start_voltage_x100 = (uint16_t)(lvc_ramp_down_end_voltage_x100 + ((padded_voltage_range_x100 * LVC_RAMP_DOWN_OFFSET_PERCENT) / 100));
+	// The LVC ramp down starts at LVC_RAMP_DOWN_OFFSET_PERCENT battery, using the padded range.
+	uint16_t lvc_ramp_down_offset_x100 = padded_voltage_range_x100 * LVC_RAMP_DOWN_OFFSET_PERCENT / 100;
+	lvc_ramp_down_start_voltage_x100 = lvc_ramp_down_end_voltage_x100 + lvc_ramp_down_offset_x100;
 
 	global_speed_limit_rpm = 0;
 	global_throttle_speed_limit_rpm_x10 = 0;

--- a/src/firmware/app.c
+++ b/src/firmware/app.c
@@ -45,6 +45,11 @@ static uint16_t lvc_voltage_x100;
 static uint16_t lvc_ramp_down_start_voltage_x100;
 static uint16_t lvc_ramp_down_end_voltage_x100;
 
+static uint16_t full_voltage_range_x100;
+static uint16_t padded_voltage_range_x100;
+static uint16_t low_voltage_pad_x100;
+static uint16_t high_voltage_pad_x100;
+
 static assist_level_data_t assist_level_data;
 static uint16_t speed_limit_ramp_interval_rpm_x10;
 
@@ -90,15 +95,16 @@ void app_init()
 
 	lvc_voltage_x100 = g_config.low_cut_off_v * 100u;
 
-	uint16_t full_voltage_range_x100 =
-		EXPAND_U16(g_config.max_battery_x100v_u16h, g_config.max_battery_x100v_u16l) - lvc_voltage_x100;
-	uint16_t padded_voltage_range_x100 = (uint16_t)(full_voltage_range_x100 *
-		(100 - BATTERY_FULL_OFFSET_PERCENT - BATTERY_EMPTY_OFFSET_PERCENT) / 100);
+	full_voltage_range_x100 = EXPAND_U16(g_config.max_battery_x100v_u16h, g_config.max_battery_x100v_u16l) - lvc_voltage_x100;
+	low_voltage_pad_x100 = full_voltage_range_x100 * BATTERY_EMPTY_OFFSET_PERCENT / 100;
+	high_voltage_pad_x100 = full_voltage_range_x100 * BATTERY_FULL_OFFSET_PERCENT / 100;
+	padded_voltage_range_x100 = full_voltage_range_x100 - low_voltage_pad_x100 - high_voltage_pad_x100;
 
-	lvc_ramp_down_end_voltage_x100 = (uint16_t)(lvc_voltage_x100 +
-		(full_voltage_range_x100 * BATTERY_EMPTY_OFFSET_PERCENT / 100));
-	lvc_ramp_down_start_voltage_x100 = (uint16_t)(lvc_ramp_down_end_voltage_x100 +
-		((padded_voltage_range_x100 * LVC_RAMP_DOWN_OFFSET_PERCENT) / 100));
+	// The LVC ramp down end is at 0% battery, which is LVC + the low padding value.
+	lvc_ramp_down_end_voltage_x100 = (uint16_t)(lvc_voltage_x100 + (full_voltage_range_x100 * BATTERY_EMPTY_OFFSET_PERCENT / 100));
+
+	// The LVC ramp down starts at 10% battery, using the padded range.
+	lvc_ramp_down_start_voltage_x100 = (uint16_t)(lvc_ramp_down_end_voltage_x100 + ((padded_voltage_range_x100 * LVC_RAMP_DOWN_OFFSET_PERCENT) / 100));
 
 	global_speed_limit_rpm = 0;
 	global_throttle_speed_limit_rpm_x10 = 0;

--- a/src/firmware/battery.c
+++ b/src/firmware/battery.c
@@ -106,12 +106,11 @@ void battery_init()
 		EXPAND_U16(g_config.max_battery_x100v_u16h, g_config.max_battery_x100v_u16l);
 
 	uint16_t battery_range_x100v = battery_max_voltage_x100v - battery_min_voltage_x100v;
+	uint16_t battery_full_pad_x100v = battery_range_x100v * BATTERY_FULL_OFFSET_PERCENT / 100;
+	uint16_t battery_empty_pad_x100v = battery_range_x100v * BATTERY_EMPTY_OFFSET_PERCENT / 100;
 
-	battery_full_x100v = battery_max_voltage_x100v -
-		((BATTERY_FULL_OFFSET_PERCENT * battery_range_x100v) / 100);
-
-	battery_empty_x100v = battery_min_voltage_x100v +
-		((BATTERY_EMPTY_OFFSET_PERCENT * battery_range_x100v) / 100);
+	battery_full_x100v = battery_max_voltage_x100v - battery_full_pad_x100v;
+	battery_empty_x100v = battery_min_voltage_x100v + battery_empty_pad_x100v;
 }
 
 void battery_process()


### PR DESCRIPTION
Proposing a safer method for this computation. If the input voltage to the clamping function is too low, the direct cast to uint8_t can cause the result to wrap. But this can even happen when casting the lvc_voltage. For example: 

max_voltage = 58.8; (set in GUI)
lvc_voltage = 42; (set in GUI)
full_voltage_range_x100 = 1679;
padded_voltage_range_x100 = 1410; (using default padding of 8% on each side, set in fw)
lvc_ramp_down_end_voltage_x100 = 4334;
lvc_ramp_down_start_voltage_x100 = 4475;
LVC_LOW_CURRENT_PERCENT = 20; (default in fw)

Input voltage for the MAP32 function is limited to lvc_voltage_x100, but in this case the MAP32 function would actually wrap

uint8_t tmp = (uint8_t)MAP32(4200, 4334, 4475, 20, 100);

Gives tmp = 200 since the result of MAP32 is negative. 

Safer to cast to int8_t so the result is between -127 and 127, then CLAMP from 0 to 100, then cast back to uint8_t. 
